### PR TITLE
bugfixes + naive reindexing endpoint

### DIFF
--- a/app/reporting/reporting.go
+++ b/app/reporting/reporting.go
@@ -161,7 +161,7 @@ func (a *app) storeToInventoryDev(storeRes interface{}) (*model.InvDevice, error
 
 		if n != "" {
 			a := model.InvDeviceAttribute{
-				Name:  n,
+				Name:  model.Redot(n),
 				Scope: s,
 				Value: v,
 			}

--- a/app/reporting/reporting.go
+++ b/app/reporting/reporting.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/mendersoftware/reporting/client/inventory"
 	"github.com/mendersoftware/reporting/model"
 	"github.com/mendersoftware/reporting/store"
 )
@@ -38,12 +39,14 @@ type App interface {
 }
 
 type app struct {
-	store store.Store
+	store     store.Store
+	invClient inventory.Client
 }
 
-func NewApp(store store.Store) App {
+func NewApp(store store.Store, client inventory.Client) App {
 	return &app{
-		store: store,
+		store:     store,
+		invClient: client,
 	}
 }
 

--- a/app/server/server.go
+++ b/app/server/server.go
@@ -29,6 +29,7 @@ import (
 
 	api "github.com/mendersoftware/reporting/api/http"
 	"github.com/mendersoftware/reporting/app/reporting"
+	"github.com/mendersoftware/reporting/client/inventory"
 	dconfig "github.com/mendersoftware/reporting/config"
 	"github.com/mendersoftware/reporting/store"
 )
@@ -50,7 +51,12 @@ func InitAndRun(conf config.Reader, store store.Store) error {
 
 	var listen = conf.GetString(dconfig.SettingListen)
 
-	reporting := reporting.NewApp(store)
+	invClient := inventory.NewClient(
+		conf.GetString(dconfig.SettingInventoryAddr),
+		false,
+	)
+
+	reporting := reporting.NewApp(store, invClient)
 
 	var router = api.NewRouter(reporting)
 	srv := &http.Server{

--- a/client/inventory/client.go
+++ b/client/inventory/client.go
@@ -1,0 +1,128 @@
+// Copyright 2021 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package inventory
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/mendersoftware/go-lib-micro/log"
+	"github.com/pkg/errors"
+
+	"github.com/mendersoftware/reporting/model"
+)
+
+const (
+	urlSearch      = "/api/internal/v2/inventory/tenants/:tid/filters/search"
+	defaultTimeout = 10 * time.Second
+)
+
+//go:generate ../../utils/mockgen.sh
+type Client interface {
+	//GetDevices uses the search endpoint to get devices just by ids (not filters)
+	GetDevices(ctx context.Context, tid string, deviceIDs []string) ([]model.InvDevice, error)
+}
+
+type client struct {
+	client  *http.Client
+	urlBase string
+}
+
+type reqGetDevices struct {
+}
+
+func NewClient(urlBase string, skipVerify bool) *client {
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: skipVerify},
+	}
+
+	return &client{
+		client: &http.Client{
+			Transport: tr,
+		},
+		urlBase: urlBase,
+	}
+}
+
+func (c *client) GetDevices(ctx context.Context, tid string, deviceIDs []string) ([]model.InvDevice, error) {
+	l := log.FromContext(ctx)
+
+	getReq := &GetDevsReq{
+		DeviceIDs: deviceIDs,
+	}
+
+	body, err := json.Marshal(getReq)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to serialize get devices request")
+	}
+
+	rd := bytes.NewReader(body)
+
+	url := joinURL(c.urlBase, urlSearch)
+	url = strings.Replace(url, ":tid", tid, 1)
+
+	req, err := http.NewRequest(http.MethodPost, url, rd)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to create request")
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	ctx, cancel := context.WithTimeout(ctx, defaultTimeout)
+	defer cancel()
+
+	rsp, err := c.client.Do(req.WithContext(ctx))
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to submit %s %s", req.Method, req.URL)
+	}
+	defer rsp.Body.Close()
+
+	body, err = ioutil.ReadAll(rsp.Body)
+	if err != nil {
+		body = []byte("<failed to read>")
+	}
+
+	if rsp.StatusCode != http.StatusOK {
+		l.Errorf("request %s %s failed with status %v, response: %s",
+			req.Method, req.URL, rsp.Status, body)
+
+		return nil, errors.Errorf(
+			"%s %s request failed with status %v", req.Method, req.URL, rsp.Status)
+	}
+
+	var invDevs []model.InvDevice
+	err = json.Unmarshal(body, &invDevs)
+	if err != nil {
+		return nil, errors.New("failed to parse inventory device(s)")
+	}
+
+	return invDevs, nil
+}
+
+func joinURL(base, url string) string {
+	if strings.HasPrefix(url, "/") {
+		url = url[1:]
+	}
+	if !strings.HasSuffix(base, "/") {
+		base = base + "/"
+	}
+	return base + url
+
+}

--- a/client/inventory/client.go
+++ b/client/inventory/client.go
@@ -45,9 +45,6 @@ type client struct {
 	urlBase string
 }
 
-type reqGetDevices struct {
-}
-
 func NewClient(urlBase string, skipVerify bool) *client {
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: skipVerify},
@@ -117,9 +114,7 @@ func (c *client) GetDevices(ctx context.Context, tid string, deviceIDs []string)
 }
 
 func joinURL(base, url string) string {
-	if strings.HasPrefix(url, "/") {
-		url = url[1:]
-	}
+	url = strings.TrimPrefix(url, "/")
 	if !strings.HasSuffix(base, "/") {
 		base = base + "/"
 	}

--- a/client/inventory/query.go
+++ b/client/inventory/query.go
@@ -1,0 +1,20 @@
+// Copyright 2021 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+package inventory
+
+//GetDevsReq is a stripped down inventory search query
+// default max 20 devices
+type GetDevsReq struct {
+	DeviceIDs []string `json:"device_ids"`
+}

--- a/config/config.go
+++ b/config/config.go
@@ -29,6 +29,9 @@ const (
 	// SettingElasticsearchAddressesDefault is the default value for the elasticsearch addresses
 	SettingElasticsearchAddressesDefault = "http://localhost:9200"
 
+	SettingInventoryAddr        = "inventory_addr"
+	SettingInventoryAddrDefault = "http://mender-inventory:8080/"
+
 	// SettingDebugLog is the config key for the truning on the debug log
 	SettingDebugLog = "debug_log"
 	// SettingDebugLogDefault is the default value for the debug log enabling
@@ -41,5 +44,6 @@ var (
 		{Key: SettingListen, Value: SettingListenDefault},
 		{Key: SettingElasticsearchAddresses, Value: SettingElasticsearchAddressesDefault},
 		{Key: SettingDebugLog, Value: SettingDebugLogDefault},
+		{Key: SettingInventoryAddr, Value: SettingInventoryAddrDefault},
 	}
 )

--- a/model/device.go
+++ b/model/device.go
@@ -94,7 +94,7 @@ func NewDeviceFromEsSource(source map[string]interface{}) (*Device, error) {
 
 		if n != "" {
 			attr := NewInventoryAttribute(s).
-				SetName(n).
+				SetName(Redot(n)).
 				SetVal(v)
 
 			dev.handleSpecialAttr(attr)

--- a/model/device.go
+++ b/model/device.go
@@ -478,6 +478,11 @@ func (d *Device) MarshalJSON() ([]byte, error) {
 		m[name] = val
 	}
 
+	for _, a := range d.SystemAttributes {
+		name, val := a.Map()
+		m[name] = val
+	}
+
 	return json.Marshal(m)
 }
 

--- a/model/device.go
+++ b/model/device.go
@@ -98,7 +98,9 @@ func NewDeviceFromEsSource(source map[string]interface{}) (*Device, error) {
 				SetVal(v)
 
 			dev.handleSpecialAttr(attr)
-			dev.AppendAttr(attr)
+			if err := dev.AppendAttr(attr); err != nil {
+				return nil, err
+			}
 		}
 	}
 
@@ -297,23 +299,22 @@ func (a *InventoryAttribute) SetNumerics(val []float64) *InventoryAttribute {
 // SetVal inspects the 'val' type and sets the correct subtype field
 // useful for translating from inventory attributes (interface{})
 func (a *InventoryAttribute) SetVal(val interface{}) *InventoryAttribute {
-	switch val.(type) {
+	switch val := val.(type) {
 	case float64:
-		a.SetNumeric(val.(float64))
+		a.SetNumeric(val)
 	case string:
-		a.SetString(val.(string))
+		a.SetString(val)
 	case []interface{}:
-		ival := val.([]interface{})
-		switch ival[0].(type) {
+		switch val[0].(type) {
 		case float64:
-			nums := make([]float64, len(ival))
-			for i, v := range ival {
+			nums := make([]float64, len(val))
+			for i, v := range val {
 				nums[i] = v.(float64)
 			}
 			a.SetNumerics(nums)
 		case string:
-			strs := make([]string, len(ival))
-			for i, v := range ival {
+			strs := make([]string, len(val))
+			for i, v := range val {
 				strs[i] = v.(string)
 			}
 			a.SetStrings(strs)

--- a/model/inventory_device.go
+++ b/model/inventory_device.go
@@ -14,11 +14,23 @@
 package model
 
 import (
+	"encoding/json"
 	"time"
 )
 
 // 1:1 port of the inventory device
 // for inventory api compat
+const (
+	AttrScopeInventory = "inventory"
+	AttrScopeIdentity  = "identity"
+	AttrScopeSystem    = "system"
+
+	AttrNameID      = "id"
+	AttrNameGroup   = "group"
+	AttrNameStatus  = "status"
+	AttrNameUpdated = "updated_ts"
+	AttrNameCreated = "created_ts"
+)
 
 type DeviceID string
 type GroupName string
@@ -48,4 +60,18 @@ type InvDevice struct {
 
 	//device object revision
 	Revision uint `json:"-" bson:"revision,omitempty"`
+}
+
+func (d *DeviceAttributes) UnmarshalJSON(b []byte) error {
+	err := json.Unmarshal(b, (*[]InvDeviceAttribute)(d))
+	if err != nil {
+		return err
+	}
+	for i := range *d {
+		if (*d)[i].Scope == "" {
+			(*d)[i].Scope = AttrScopeInventory
+		}
+	}
+
+	return nil
 }

--- a/model/query.go
+++ b/model/query.go
@@ -22,6 +22,8 @@ import (
 const (
 	defaultPage    = 0
 	defaultPerPage = 20
+
+	attrDeviceID = "id"
 )
 
 type ArrayOpts int
@@ -225,7 +227,11 @@ func NewFilter(fp FilterPredicate, arrOpts ArrayOpts, typeOpts Type) (*filter, e
 		}
 	}
 
-	attr := ToAttr(fp.Scope, fp.Attribute, typ)
+	// some special attributes translate to non-scoped, predefined fields
+	attr := parseSpecialAttr(fp.Attribute)
+	if attr == "" {
+		attr = ToAttr(fp.Scope, fp.Attribute, typ)
+	}
 
 	return &filter{
 		attr: attr,
@@ -506,4 +512,16 @@ func BuildQuery(parms SearchParams) (Query, error) {
 	}
 
 	return query, nil
+}
+
+// parseSpecialAttr detects attributes like `Device ID`, which
+// translate to plain flat fields (e.g. 'id'), and not
+// scoped attributes
+func parseSpecialAttr(attr string) string {
+	switch attr {
+	case attrDeviceID:
+		return "id"
+	default:
+		return ""
+	}
 }

--- a/model/util.go
+++ b/model/util.go
@@ -11,42 +11,27 @@
 //    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //    See the License for the specific language governing permissions and
 //    limitations under the License.
-
 package model
 
-// common enum for some type introspections we'll need
-type Type int
-
-const (
-	TypeAny Type = iota
-	TypeStr
-	TypeNum
-	TypeBool
+import (
+	"strings"
 )
 
-// scope prefixes
 const (
-	scopeInventory = "inventory"
-	scopeIdentity  = "identity"
-	scopeCustom    = "custom"
-	scopeSystem    = "system"
-)
-
-// type enum/suffixes
-const (
-	typeStr = "str"
-	typeNum = "num"
+	runeDot = '\uFF0E'
 )
 
 var (
-	attrSuffixes = map[Type]string{
-		TypeStr: typeStr,
-		TypeNum: typeNum,
-	}
+	dedotter = strings.NewReplacer(".", string(runeDot))
+	redotter = strings.NewReplacer(string(runeDot), ".")
 )
 
-// toAttr composes the flat-style attribute name based on
-// scope, name, and type
-func ToAttr(scope, name string, typ Type) string {
-	return scope + "_" + Dedot(name) + "_" + attrSuffixes[typ]
+// Dedot replaces '.' in a name to make it digestible by ES
+func Dedot(name string) string {
+	return dedotter.Replace(name)
+}
+
+// Redot reverses dedotting
+func Redot(name string) string {
+	return redotter.Replace(name)
 }

--- a/store/store.go
+++ b/store/store.go
@@ -197,12 +197,12 @@ func (s *store) GetDevice(ctx context.Context, tenant, devid string) (*model.Dev
 	}
 
 	res, err := req.Do(ctx, s.client)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get device")
+	}
 	defer res.Body.Close()
 
-	switch {
-	case err != nil:
-		return nil, errors.Wrap(err, "failed to get device")
-	case res.IsError():
+	if res.IsError() {
 		if res.StatusCode == http.StatusNotFound {
 			return nil, nil
 		} else {
@@ -242,9 +242,12 @@ func (s *store) UpdateDevice(ctx context.Context, tenantID, deviceID string, upd
 	}
 
 	res, err := req.Do(ctx, s.client)
+	if err != nil {
+		return errors.Wrap(err, "failed to update device in ES")
+	}
+
 	defer res.Body.Close()
 
-	//DEBUG
 	var esbody map[string]interface{}
 	if err := json.NewDecoder(res.Body).Decode(&esbody); err != nil {
 		return err

--- a/store/store.go
+++ b/store/store.go
@@ -29,6 +29,7 @@ import (
 	"github.com/mendersoftware/go-lib-micro/log"
 	_ "github.com/mendersoftware/go-lib-micro/log"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 
 	"github.com/mendersoftware/reporting/model"
 )
@@ -149,9 +150,15 @@ func (s *store) Migrate(ctx context.Context) error {
 }
 
 func (s *store) Search(ctx context.Context, query interface{}) (model.M, error) {
+	l := log.FromContext(ctx)
+
 	var buf bytes.Buffer
 	if err := json.NewEncoder(&buf).Encode(query); err != nil {
 		return nil, err
+	}
+
+	if l.Logger.IsLevelEnabled(logrus.DebugLevel) {
+		l.Debugf("es query:\n%v\n", buf.String())
 	}
 
 	id := identity.FromContext(ctx)


### PR DESCRIPTION
https://tracker.mender.io/browse/MEN-4844

- the fixes were figured out while manual testing with the ui, and are mostly critical
- the reindexing endpoint was introduced just to get working e2e inventory data flows (there's a real task for it - https://tracker.mender.io/browse/MEN-4845, it needs prob. bulk processing)

with this pr, all inventory attributes are propagated to ES and the ui uses the `reporting` search endpoint instead of `inventory`. 
