### PR TITLE
MEN-4970: provision and use a single elasticsearch index for devices

### DIFF
--- a/api/http/internal.go
+++ b/api/http/internal.go
@@ -48,10 +48,9 @@ func (mc *InternalController) Search(c *gin.Context) {
 	tid := c.Param("tenant_id")
 
 	ctx := c.Request.Context()
-
 	ctx = identity.WithContext(ctx, &identity.Identity{Tenant: tid})
 
-	params, err := parseSearchParams(c)
+	params, err := parseSearchParams(ctx, c)
 
 	if err != nil {
 		rest.RenderError(c,

--- a/api/http/internal_test.go
+++ b/api/http/internal_test.go
@@ -102,6 +102,7 @@ func TestInternalSearch(t *testing.T) {
 				Attribute: "ip4",
 				Order:     "asc",
 			}},
+			TenantID: "123456789012345678901234",
 		},
 
 		Code: http.StatusOK,
@@ -150,7 +151,9 @@ func TestInternalSearch(t *testing.T) {
 			return app
 		},
 		TenantID: "123456789012345678901234",
-		Params:   &model.SearchParams{},
+		Params: &model.SearchParams{
+			TenantID: "123456789012345678901234",
+		},
 
 		Code:     http.StatusOK,
 		Response: []model.InvDevice{},
@@ -165,6 +168,7 @@ func TestInternalSearch(t *testing.T) {
 				Attribute: "rootpwd",
 				Value:     true,
 			}},
+			TenantID: "123456789012345678901234",
 		},
 		Code:     http.StatusBadRequest,
 		Response: rest.Error{Err: "malformed request body: type: must be a valid value."},
@@ -195,6 +199,7 @@ func TestInternalSearch(t *testing.T) {
 				Attribute: "ip4",
 				Order:     "asc",
 			}},
+			TenantID: "123456789012345678901234",
 		},
 
 		Code:     http.StatusInternalServerError,

--- a/api/http/management_test.go
+++ b/api/http/management_test.go
@@ -110,6 +110,7 @@ func TestManagementSearch(t *testing.T) {
 				Attribute: "ip4",
 				Order:     "asc",
 			}},
+			TenantID: "123456789012345678901234",
 		},
 
 		Code: http.StatusOK,
@@ -163,7 +164,9 @@ func TestManagementSearch(t *testing.T) {
 				Tenant:  "123456789012345678901234",
 			},
 		),
-		Params: &model.SearchParams{},
+		Params: &model.SearchParams{
+			TenantID: "123456789012345678901234",
+		},
 
 		Code:     http.StatusOK,
 		Response: []model.InvDevice{},
@@ -188,7 +191,8 @@ func TestManagementSearch(t *testing.T) {
 			DeviceGroups: []string{"group1", "group2"},
 		}),
 		Params: &model.SearchParams{
-			Groups: []string{"group1", "group2"},
+			Groups:   []string{"group1", "group2"},
+			TenantID: "123456789012345678901234",
 		},
 
 		Code:     http.StatusOK,
@@ -209,6 +213,7 @@ func TestManagementSearch(t *testing.T) {
 				Attribute: "rootpwd",
 				Value:     true,
 			}},
+			TenantID: "123456789012345678901234",
 		},
 		Code:     http.StatusBadRequest,
 		Response: rest.Error{Err: "malformed request body: type: must be a valid value."},
@@ -244,6 +249,7 @@ func TestManagementSearch(t *testing.T) {
 				Attribute: "ip4",
 				Order:     "asc",
 			}},
+			TenantID: "123456789012345678901234",
 		},
 
 		Code:     http.StatusInternalServerError,

--- a/app/reporting/reindexer.go
+++ b/app/reporting/reindexer.go
@@ -207,8 +207,10 @@ func fetch(inchan chan []reindexReq, client inventory.Client, store store.Store)
 
 			for _, r := range batch {
 				j := mergeJob{
-					Tenant: r.Tenant,
-					Device: r.Device,
+					Tenant:  r.Tenant,
+					Device:  r.Device,
+					Index:   store.GetDevicesIndex(r.Tenant),
+					Routing: store.GetDevicesRoutingKey(r.Tenant),
 					// we know we can only have inventory for now
 					// later, find out which sources asked for reindex
 					SrcInventory: &mergeSrcInventory{},
@@ -283,6 +285,8 @@ func fetch(inchan chan []reindexReq, client inventory.Client, store store.Store)
 type mergeJob struct {
 	Tenant       string
 	Device       string
+	Index        string
+	Routing      string
 	SrcInventory *mergeSrcInventory
 	SrcElastic   *mergeSrcElastic
 }
@@ -329,8 +333,10 @@ func merge(j *mergeJob) (*store.BulkItem, error) {
 
 	action := &store.BulkAction{
 		Desc: &store.BulkActionDesc{
-			Tenant: j.Tenant,
-			ID:     j.Device,
+			ID:      j.Device,
+			Index:   j.Index,
+			Routing: j.Routing,
+			Tenant:  j.Tenant,
 		},
 	}
 

--- a/app/reporting/reporting.go
+++ b/app/reporting/reporting.go
@@ -67,6 +67,14 @@ func (app *app) InventorySearchDevices(
 		return nil, 0, err
 	}
 
+	if searchParams.TenantID != "" {
+		query = query.Must(model.M{
+			"term": model.M{
+				"tenantID": searchParams.TenantID,
+			},
+		})
+	}
+
 	if len(searchParams.DeviceIDs) > 0 {
 		query = query.Must(model.M{
 			"terms": model.M{

--- a/config.yaml
+++ b/config.yaml
@@ -10,6 +10,24 @@
 
 # elasticsearch_addresses: "http://localhost:9200"
 
+# Devices: index name
+# Defauls to: "devices"
+# Overwrite with environment variable: REPORTING_ELASTICSEARCH_DEVICES_INDEX_NAME
+
+# elasticsearch_devices_index_name: "devices"
+
+# Devices: number of shards
+# Defauls to: 1
+# Overwrite with environment variable: REPORTING_ELASTICSEARCH_DEVICES_INDEX_SHARDS
+
+# elasticsearch_devices_index_shards: 1
+
+# Devices: number of replicas
+# Defauls to: 0
+# Overwrite with environment variable: REPORTING_ELASTICSEARCH_DEVICES_INDEX_REPLICAS
+
+# elasticsearch_devices_index_replicas: 0
+
 # Reindex batch size, in number of buffered requests
 # Defauls to: 20
 # Overwrite with environment variable: REPORTING_REINDEX_BATCH_SIZE

--- a/config/config.go
+++ b/config/config.go
@@ -29,6 +29,27 @@ const (
 	// SettingElasticsearchAddressesDefault is the default value for the elasticsearch addresses
 	SettingElasticsearchAddressesDefault = "http://localhost:9200"
 
+	// SettingElasticsearchDevicesIndexName is the config key for the elasticsearch devices
+	// index name
+	SettingElasticsearchDevicesIndexName = "elasticsearch_devices_index_name"
+	// SettingElasticsearchDevicesIndexNameDefault is the default value for the elasticsearch
+	// devices index name
+	SettingElasticsearchDevicesIndexNameDefault = "devices"
+
+	// SettingElasticsearchDevicesIndexShards is the config key for the elasticsearch devices
+	// index shards
+	SettingElasticsearchDevicesIndexShards = "elasticsearch_devices_index_shards"
+	// SettingElasticsearchDevicesIndexShardsDefault is the default value for the elasticsearch
+	// devices index shards
+	SettingElasticsearchDevicesIndexShardsDefault = 1
+
+	// SettingElasticsearchDevicesIndexReplicas is the config key for the elasticsearch devices
+	// index replicas
+	SettingElasticsearchDevicesIndexReplicas = "elasticsearch_devices_index_replicas"
+	// SettingElasticsearchDevicesIndexReplicasDefault is the default value for the
+	// elasticsearch devices index replicas
+	SettingElasticsearchDevicesIndexReplicasDefault = 0
+
 	SettingInventoryAddr        = "inventory_addr"
 	SettingInventoryAddrDefault = "http://mender-inventory:8080/"
 
@@ -61,6 +82,12 @@ var (
 	Defaults = []config.Default{
 		{Key: SettingListen, Value: SettingListenDefault},
 		{Key: SettingElasticsearchAddresses, Value: SettingElasticsearchAddressesDefault},
+		{Key: SettingElasticsearchDevicesIndexName,
+			Value: SettingElasticsearchDevicesIndexNameDefault},
+		{Key: SettingElasticsearchDevicesIndexShards,
+			Value: SettingElasticsearchDevicesIndexShardsDefault},
+		{Key: SettingElasticsearchDevicesIndexReplicas,
+			Value: SettingElasticsearchDevicesIndexReplicasDefault},
 		{Key: SettingDebugLog, Value: SettingDebugLogDefault},
 		{Key: SettingInventoryAddr, Value: SettingInventoryAddrDefault},
 		{Key: SettingReindexBuffLen, Value: SettingReindexBuffLenDefault},

--- a/main.go
+++ b/main.go
@@ -79,7 +79,6 @@ func doMain(args []string) {
 		},
 	}
 	app.Usage = "Reporting"
-	app.Version = "1.0.0"
 	app.Action = cmdServer
 
 	app.Before = func(args *cli.Context) error {
@@ -145,8 +144,15 @@ func cmdMigrate(args *cli.Context) error {
 
 func getStore(args *cli.Context) (store.Store, error) {
 	addresses := config.Config.GetStringSlice(dconfig.SettingElasticsearchAddresses)
+	devicesIndexName := config.Config.GetString(dconfig.SettingElasticsearchDevicesIndexName)
+	deviceesIndexShards := config.Config.GetInt(dconfig.SettingElasticsearchDevicesIndexShards)
+	deviceesIndexReplicas := config.Config.GetInt(
+		dconfig.SettingElasticsearchDevicesIndexReplicas)
 	store, err := store.NewStore(
 		store.WithServerAddresses(addresses),
+		store.WithDevicesIndexName(devicesIndexName),
+		store.WithDevicesIndexShards(deviceesIndexShards),
+		store.WithDevicesIndexReplicas(deviceesIndexReplicas),
 	)
 	if err != nil {
 		return nil, err

--- a/model/filters.go
+++ b/model/filters.go
@@ -44,6 +44,7 @@ type SearchParams struct {
 	Attributes []SelectAttribute `json:"attributes"`
 	DeviceIDs  []string          `json:"device_ids"`
 	Groups     []string          `json:"-"`
+	TenantID   string            `json:"-"`
 }
 
 type Filter struct {

--- a/store/index.go
+++ b/store/index.go
@@ -14,15 +14,13 @@
 
 package store
 
-const (
-	indexDevices         = "devices"
-	indexDevicesTemplate = `{
-	"index_patterns": ["devices*"],
+const indexDevicesTemplate = `{
+	"index_patterns": ["%s*"],
 	"priority": 1,
 	"template": {
 		"settings": {
-			"number_of_shards": 1,
-			"number_of_replicas": 1
+			"number_of_shards": %d,
+			"number_of_replicas": %d
 		},
 		"mappings": {
 			"dynamic": "runtime",
@@ -91,4 +89,3 @@ const (
 		}
 	}
 }`
-)

--- a/store/mocks/Store.go
+++ b/store/mocks/Store.go
@@ -135,6 +135,34 @@ func (_m *Store) GetDevices(ctx context.Context, tenantDevs map[string][]string)
 	return r0, r1
 }
 
+// GetDevicesIndex provides a mock function with given fields: tid
+func (_m *Store) GetDevicesIndex(tid string) string {
+	ret := _m.Called(tid)
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func(string) string); ok {
+		r0 = rf(tid)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
+// GetDevicesRoutingKey provides a mock function with given fields: tid
+func (_m *Store) GetDevicesRoutingKey(tid string) string {
+	ret := _m.Called(tid)
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func(string) string); ok {
+		r0 = rf(tid)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
 // IndexDevice provides a mock function with given fields: ctx, device
 func (_m *Store) IndexDevice(ctx context.Context, device *model.Device) error {
 	ret := _m.Called(ctx, device)

--- a/tests/tests/test_mgmt.py
+++ b/tests/tests/test_mgmt.py
@@ -458,7 +458,7 @@ class TestManagementSearch:
                         )
                     ],
                 ),
-                http_code=500,
+                http_code=200,
                 result=[],
             ),
             _TestCase(

--- a/tests/tests/utils.py
+++ b/tests/tests/utils.py
@@ -48,7 +48,9 @@ def index_device(es: Elasticsearch, device: InternalDevice):
     except KeyError:
         pass
     doc["tenantID"] = device.tenant_id
-    es.index(f"devices-{device.tenant_id}", doc, refresh="wait_for", id=device.id)
+    es.index(
+        f"devices", doc, routing=device.tenant_id, refresh="wait_for", id=device.id
+    )
 
 
 def attributes_to_document(attrs: list[Attribute]) -> dict[str, object]:


### PR DESCRIPTION
Update the service to provision and use a single, configurable
elasticsearch index to store the devices. The number of shards and
replicas is configurable. The defaults are one single shard, and no
replicas. To improve performances, the tenant ID is used as routing key
both when indexing and querying the data. In case of open-source, empty
routing key is used, which means the internal implementation in
elasticsearch will use the document ID.

Changelog: none

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>