### PR TITLE
QA-235: pipeline: Switch to static checks by golangci-lint

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,7 +14,7 @@ stages:
 
 include:
   - project: 'Northern.tech/Mender/mendertesting'
-    file: '.gitlab-ci-check-golang-static.yml'
+    file: '.gitlab-ci-check-golang-lint.yml'
   - project: 'Northern.tech/Mender/mendertesting'
     file: '.gitlab-ci-check-golang-unittests.yml'
   - project: 'Northern.tech/Mender/mendertesting'
@@ -27,14 +27,6 @@ include:
     file: '.gitlab-ci-github-status-updates.yml'
   - project: 'Northern.tech/Mender/mendertesting'
     file: '.gitlab-ci-check-docker-build.yml'
-
-test:static:
-  image: golangci/golangci-lint:v1.42.0
-  needs: []
-  after_script: []
-  before_script: []
-  script:
-    - golangci-lint run -v
 
 test:acceptance:
   stage: test

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,14 +33,16 @@ linters:
 
 linters-settings:
   gocyclo:
-    min-complexity: 20 # default is 30.
+    # default is 30.
+    min-complexity: 20
 
   goimports:
+    # to be edited by the template
     local-prefixes:
-      "github.com/mendersoftware/devicemonitor"
+      "github.com/mendersoftware/reporting"
 
   lll:
     # max line length, lines longer will be reported. Default is 120.
     line-length: 100
     # tab width in spaces. Default to 1.
-    tab-width: 8
+    tab-width: 4

--- a/app/indexer/indexer.go
+++ b/app/indexer/indexer.go
@@ -16,6 +16,7 @@ package indexer
 
 import (
 	"github.com/mendersoftware/go-lib-micro/config"
+
 	"github.com/mendersoftware/reporting/store"
 )
 


### PR DESCRIPTION
Modify the existing .golangci.yml to follow standard and fix one
goimports linting issue.